### PR TITLE
ELEC-486: Autostart

### DIFF
--- a/client/src/ts/dd_main.ts
+++ b/client/src/ts/dd_main.ts
@@ -105,7 +105,7 @@ power_consumption_graph.dataUpdate = () => UpdatePlot();
 const speedDialOptions = new dial.DialOptions();
 speedDialOptions.angleOffset = 0.5 * Math.PI;
 speedDialOptions.angleArc = 1.5 * Math.PI;
-speedDialOptions.max = 120;
+speedDialOptions.max = 130;
 
 const socDialOptions = new dial.DialOptions();
 socDialOptions.angleOffset = 0.5 * Math.PI;
@@ -160,8 +160,8 @@ function updateDate(): void {
 // Initializations
 
 const ws = new WebSocket('ws://localhost:8080/ws');
-speedDial.value(120);
-batteryDial.value(100);
+speedDial.value(0);
+batteryDial.value(0);
 solarReadout.value(0);
 consumptionReadout.value(0);
 document.getElementById('state').innerHTML = 'N';

--- a/client/src/ts/dial.ts
+++ b/client/src/ts/dial.ts
@@ -114,6 +114,7 @@ export class Dial {
         this._value = Math.round(new_val);
         this.redraw();
       };
+      this._animator.cancel();
       this._animator.animate(this._value, value, update);
       return this;
     }

--- a/driver_display_startup.sh
+++ b/driver_display_startup.sh
@@ -6,7 +6,7 @@ nice ./bin/telemetry start --tty=/dev/ttyAMA0 --db=can.db \
   --schema=can_messages.asciipb &
 
 # Start a very minimal version of Chromium in fullscreen
-chromium-browser --kiosk --incognito --noerrdialogs --disable-infobars \ 
+chromium-browser --kiosk --incognito --noerrdialogs --disable-infobars \
   http://localhost:8080/driver_display.html &
 
 


### PR DESCRIPTION
Fixes a bug in the autostart script and makes the default values in the display all 0s.

To update the install on the PI:

```bash
cd /home/pi/telemetry
rm -rf .
```

Download the release `arm32_linux.zip` from the releases page.

Unzip the contents of the zipfile in `/home/pi/telemetry`. I have already configured the PI to autostart the rest.