### PR TITLE
ELEC-571: README lacks information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,55 @@ The telemetry client is a web frontend that displays data pushed from the server
 over a WebSocket connection. This is written in TypeScript.
 
 ### Getting Started
+These steps must be followed **after** setting up telemetry-server.
+
 We use [yarn](https://yarnpkg.com/en/) to manage dependencies&mdash;it is 
 compatible with `npm`, but is a little faster and allows us to specify a
 `yarn.lock` file.
 
 ```bash
+cd $GOPATH/src/github.com/uw-midsun/telemetry/client
 yarn install
+```
+
+We use TypeScript extensively, so you will need to compile the TypeScript files. First, install TypeScript, then compile the code with our `tsconfig.json` configuration.
+
+```bash
+cd $GOPATH/src/github.com/uw-midsun/telemetry/client
+tsc
+```
+
+For some stylesheets, we use Sass, so you will need to install that as well. Then, compile the Sass stylesheets to CSS.
+
+```bash
+cd $GOPATH/src/github.com/uw-midsun/telemetry/client/src/css
+sass stylesheet.scss stylesheet.css
+```
+
+To start serving the webpage, run the server executable with appropriate options specified. The driver display webpage will be accessible at <IP_ADDRESS>:8080/driver_display.html.
+
+```bash
+cd $GOPATH/src/github.com/uw-midsun/telemetry
+./bin/telemetry start -f --schema=can_messages.asciipb
 ```
 
 ## telemetry-server
 
 ### Getting Started
+We use Go to write backend code for the telemetry server. Follow the appropriate instructions to install Go for your operating system, then check that environment variables are set up correctly by running `go env`.
+
 We use [Glide](https://github.com/Masterminds/glide) to manage vendored
 dependencies.
 
-Once you've installed Glide, get the code
+When installing Glide, it may complain that you do not have a `bin` folder in your $GOPATH. Rectify this by creating a bin folder, setting $GOBIN, then adding it to your path.
+
+```bash
+cd $GOPATH && mkdir bin
+export GOBIN=$GOPATH/bin
+export PATH=$PATH:$GOBIN
+```
+
+Once you've installed Glide, get the code.
 
 ```bash
 go get -d github.com/uw-midsun/telemetry


### PR DESCRIPTION
README did not mention several dependencies which I ran into while setting the telemetry server/client up. I've added some more instructions to help new members get set up faster and address some common errors.