### PR TITLE
ELEC-572: Fix loading of CSS/scripts in Chrome

### DIFF
--- a/client/src/driver_display.html
+++ b/client/src/driver_display.html
@@ -6,8 +6,8 @@
     <title>UWMidsun Driver Display</title>
     <meta name="description" content="UWMidsun Driver Display">
     <meta name="author" content="UWMidsun">
-    <link href="css/stylesheet.css" rel="stylesheet">
-    <link href="css/plottable.css" rel="stylesheet">
+    <link type="text/css" href="css/stylesheet.css" rel="stylesheet">
+    <link type="text/css" href="css/plottable.css" rel="stylesheet">
 </head>
 
 <body>
@@ -73,9 +73,9 @@
             </div>
         </div>
     </div>
-    <script src="static/d3.js"></script>
-    <script src="static/plottable.js"></script>
-    <script data-main="js/dd" src="static/require.js"></script>
+    <script type="text/javascript" src="static/d3.js"></script>
+    <script type="text/javascript" src="static/plottable.js"></script>
+    <script type="text/javascript" data-main="js/dd" src="static/require.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Strict MIME type checking prevented CSS and scripts from being loaded without an appropriate "type" in the link/script tag.