### PR TITLE
ELEC-485: Fixing `make test-coverage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ COVERAGE_XML = $(COVERAGE_DIR)/coverage.xml
 COVERAGE_HTML = $(COVERAGE_DIR)/index.html
 .PHONY: test-coverage test-coverage-tools
 test-coverage-tools: | $(GOCOVMERGE) $(GOCOV) $(GOCOVXML)
-test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage.$(shell date -Iseconds)
+test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage.$(shell date +%F_%H-%M-%S)
 test-coverage: fmt lint vendor test-coverage-tools | $(BASE) ; $(info running coverage tests...) @ ## Run coverage tests
 	$Q mkdir -p $(COVERAGE_DIR)/coverage
 	$Q cd $(BASE) && for pkg in $(TESTPKGS); do \
@@ -100,7 +100,7 @@ test-coverage: fmt lint vendor test-coverage-tools | $(BASE) ; $(info running co
 					grep '^$(PACKAGE)/' | grep -v '^$(PACKAGE)/vendor/' | \
 					tr '\n' ',')$$pkg \
 			-covermode=$(COVERAGE_MODE) \
-			-coverprofile="$(COVERAGE_DIR)/coverage/`echo $$pkg | tr "/" "-"`.cover" $$pkg ;\
+			-coverprofile="$(COVERAGE_DIR)/coverage/`echo $$pkg | tr "/" "-"`.cover" $$pkg || exit 1; \
 	 done
 	$Q $(GOCOVMERGE) $(COVERAGE_DIR)/coverage/*.cover > $(COVERAGE_PROFILE)
 	$Q $(GO) tool cover -html=$(COVERAGE_PROFILE) -o $(COVERAGE_HTML)

--- a/pkg/db/can_db.go
+++ b/pkg/db/can_db.go
@@ -17,7 +17,7 @@ import (
 func RunDb(bus *pubsub.MessageBus, dbName string) {
 	db, err := sql.Open("sqlite3", dbName)
 	if err != nil {
-		log.Errorf("Failed to open db", err.Error())
+		log.Errorf("Failed to open db " + err.Error())
 		return
 	}
 	createTbl := `
@@ -38,7 +38,7 @@ func RunDb(bus *pubsub.MessageBus, dbName string) {
 		defer l.Unlock()
 		err = WriteMsg(db, msg)
 		if err != nil {
-			log.Errorf("Failed to write", err.Error())
+			log.Errorf("Failed to write " + err.Error())
 		}
 	})
 }


### PR DESCRIPTION
This PR fixes the following issues:

1. When `make test-coverage` run, it does not fail on when a build fails: https://travis-ci.org/uw-midsun/telemetry/jobs/520057059#L755

2. When you run `make test-coverage` on windows in the shared vagrant directory, it fails to create the coverage file because the date string format contains colons.

3. The db test fails because of a linter issue: https://travis-ci.org/uw-midsun/telemetry/jobs/520057059#L753